### PR TITLE
Bootstrap monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+pnpm-lock.yaml
+.DS_Store
+packages/*/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Storycraft
+
+This repo contains the Storycraft branching gamebook editor and mobile app.
+
+## Packages
+- `editor-web` – React-based web editor built with Vite
+- `mobile-app` – Expo React Native shell for reading stories
+- `shared-types` – Shared TypeScript interfaces
+
+To install dependencies run `pnpm install`.
+
+The Supabase schema is located in `supabase/schema.sql`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "Storycraft",
+  "version": "0.1.0",
+  "description": "",
+  "private": true,
+  "scripts": {
+    "test": "pnpm -r test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.5.2",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  }
+}

--- a/packages/editor-web/index.html
+++ b/packages/editor-web/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Storycraft Editor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/editor-web/package.json
+++ b/packages/editor-web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "editor-web",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "private": true,
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.5.2",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/packages/editor-web/src/main.tsx
+++ b/packages/editor-web/src/main.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const App = () => <div>Storycraft Editor</div>;
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/editor-web/tsconfig.json
+++ b/packages/editor-web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/packages/editor-web/vite.config.ts
+++ b/packages/editor-web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -1,0 +1,6 @@
+{
+  "name": "Storycraft",
+  "slug": "storycraft",
+  "version": "1.0.0",
+  "entryPoint": "src/App.tsx"
+}

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mobile-app",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "private": true
+}

--- a/packages/mobile-app/src/App.tsx
+++ b/packages/mobile-app/src/App.tsx
@@ -1,0 +1,8 @@
+import { Text, View } from 'react-native';
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Storycraft Mobile</Text>
+    </View>
+  );
+}

--- a/packages/mobile-app/tsconfig.json
+++ b/packages/mobile-app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "jsx": "react-native",
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "node"
+  }
+}

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "shared-types",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build": "tsc -p .",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "private": true,
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,0 +1,15 @@
+export interface Story {
+  id: string;
+  title: string;
+}
+
+export interface Node {
+  id: string;
+  storyId: string;
+  text: string;
+}
+
+export interface Action {
+  label: string;
+  targetId: string;
+}

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,42 @@
+-- SQL schema for Storycraft
+create table if not exists users (
+  id uuid primary key,
+  email text not null
+);
+
+create table if not exists stories (
+  id uuid primary key,
+  user_id uuid references users(id),
+  title text not null
+);
+
+create table if not exists nodes (
+  id uuid primary key,
+  story_id uuid references stories(id),
+  text text
+);
+
+create table if not exists actions (
+  id uuid primary key,
+  node_id uuid references nodes(id),
+  label text,
+  target_id uuid
+);
+
+create table if not exists revisions (
+  id uuid primary key,
+  story_id uuid references stories(id),
+  created_at timestamp default now(),
+  data jsonb
+);
+
+-- Enable row level security
+alter table stories enable row level security;
+alter table nodes enable row level security;
+alter table actions enable row level security;
+alter table revisions enable row level security;
+
+-- Example policy
+drop policy if exists "Users can read" on stories;
+create policy "Users can read" on stories
+  for select using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- initialize pnpm workspace for editor, mobile app, and shared types
- add basic Vite React setup for web editor
- scaffold Expo-based mobile app
- define shared TypeScript interfaces
- draft Supabase SQL schema

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852fb7309e0832987c6a89ce52048ae