### PR TITLE
Fix React Flow provider usage

### DIFF
--- a/packages/editor-web/src/App.tsx
+++ b/packages/editor-web/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeSupa } from '@supabase/auth-ui-shared';
 import { Session } from '@supabase/supabase-js';
 import { supabase } from './supabaseClient';
 import Editor from './Editor';
+import { ReactFlowProvider } from 'reactflow';
 
 export default function App() {
   const [session, setSession] = useState<Session | null>(null);
@@ -26,5 +27,9 @@ export default function App() {
     );
   }
 
-  return <Editor />;
+  return (
+    <ReactFlowProvider>
+      <Editor />
+    </ReactFlowProvider>
+  );
 }

--- a/packages/editor-web/src/Editor.tsx
+++ b/packages/editor-web/src/Editor.tsx
@@ -16,7 +16,6 @@ import 'reactflow/dist/style.css';
 import { useCallback, useEffect, useState } from 'react';
 import { supabase } from './supabaseClient';
 import Sidebar from './Sidebar';
-import { ReactFlowProvider } from 'reactflow';
 import ImageUpload from './ImageUpload';
 import ExportPanel from './ExportPanel';
 
@@ -178,7 +177,6 @@ export default function Editor() {
   };
 
   return (
-    <ReactFlowProvider>
       <div className="h-screen flex">
         <Sidebar />
         <div className="flex-1" onDrop={onDrop} onDragOver={onDragOver}>
@@ -242,6 +240,5 @@ export default function Editor() {
           <ExportPanel nodes={nodes} edges={edges} />
         </div>
       </div>
-    </ReactFlowProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap `Editor` with `ReactFlowProvider`
- remove redundant provider wrapping in `Editor`

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_685acc4e72c88329baeddecb07944885