### PR TITLE
Implement Phase 2 UI enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-test-renderer": "^19.1.0",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "nock": "^13.4.0"
   },
   "dependencies": {
     "@supabase/auth-ui-react": "^0.4.7",

--- a/packages/editor-web/src/App.tsx
+++ b/packages/editor-web/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Auth } from '@supabase/auth-ui-react';
 import { ThemeSupa } from '@supabase/auth-ui-shared';
 import { Session } from '@supabase/supabase-js';
-import { supabase } from './supabaseClient';
+import { api } from './supabaseClient';
 import Editor from './Editor';
 import { ReactFlowProvider } from 'reactflow';
 
@@ -10,8 +10,8 @@ export default function App() {
   const [session, setSession] = useState<Session | null>(null);
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setSession(data.session));
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+    api.client.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = api.client.auth.onAuthStateChange((_event, session) => {
       setSession(session);
     });
     return () => {
@@ -22,7 +22,7 @@ export default function App() {
   if (!session) {
     return (
       <div className="flex items-center justify-center h-screen">
-        <Auth supabaseClient={supabase} appearance={{ theme: ThemeSupa }} />
+        <Auth supabaseClient={api.client} appearance={{ theme: ThemeSupa }} />
       </div>
     );
   }

--- a/packages/editor-web/src/Editor.tsx
+++ b/packages/editor-web/src/Editor.tsx
@@ -14,10 +14,10 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import { useCallback, useEffect, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { api } from './supabaseClient';
 import Sidebar from './Sidebar';
-import ImageUpload from './ImageUpload';
 import ExportPanel from './ExportPanel';
+import NodeEditor from './NodeEditor';
 
 export default function Editor() {
   const [nodes, setNodes, onNodesChange] = useNodesState([] as Node[]);
@@ -32,19 +32,19 @@ export default function Editor() {
   }, []);
 
   const load = async () => {
-    const { data: nodeData } = await supabase
+    const { data: nodeData } = await api.client
       .from('nodes')
-      .select('id, text, image_url');
+      .select('id, title, text, image_url');
     if (nodeData) {
       const loadedNodes: Node[] = nodeData.map((n: any, idx: number) => ({
-        id: n.id,
+        id: String(n.id),
         position: { x: idx * 100, y: idx * 80 },
-        data: { label: n.text, image: n.image_url ?? '' },
+        data: { title: n.title ?? '', text: n.text ?? '', image: n.image_url ?? '' },
       }));
       setNodes(loadedNodes);
     }
 
-    const { data: actionData } = await supabase
+    const { data: actionData } = await api.client
       .from('actions')
       .select('id, node_id, target_id, label');
     if (actionData) {
@@ -60,17 +60,18 @@ export default function Editor() {
 
   const save = useCallback(
     (nodes: Node[], edges: Edge[]) => {
-      supabase
+      api.client
         .from('nodes')
         .upsert(
           nodes.map((n) => ({
-            id: n.id,
-            text: (n.data as any).label,
+            id: parseInt(n.id, 10),
+            title: (n.data as any).title,
+            text: (n.data as any).text,
             image_url: (n.data as any).image ?? null,
           }))
         );
 
-      supabase
+      api.client
         .from('actions')
         .upsert(
           edges.map((e) => ({
@@ -81,7 +82,7 @@ export default function Editor() {
           }))
         );
 
-      supabase.from('revisions').insert({
+      api.client.from('revisions').insert({
         id: crypto.randomUUID(),
         story_id: 'demo-story',
         data: { nodes, edges },
@@ -98,13 +99,14 @@ export default function Editor() {
 
   const addNode = () => {
     setHistory((h) => [...h, { nodes, edges }]);
-    const id = crypto.randomUUID();
+    const nextId =
+      nodes.reduce((max, n) => Math.max(max, parseInt(n.id, 10)), 0) + 1;
     setNodes((nds) => [
       ...nds,
       {
-        id,
+        id: String(nextId),
         position: { x: 0, y: nds.length * 80 },
-        data: { label: 'New Node', image: '' },
+        data: { title: '', text: '', image: '' },
       },
     ]);
   };
@@ -119,10 +121,11 @@ export default function Editor() {
     const type = event.dataTransfer.getData('application/reactflow');
     if (type) {
       const position = reactFlow.project({ x: event.clientX, y: event.clientY });
-      const id = crypto.randomUUID();
+      const nextId =
+        nodes.reduce((max, n) => Math.max(max, parseInt(n.id, 10)), 0) + 1;
       setNodes((nds) => [
         ...nds,
-        { id, position, data: { label: 'New Node', image: '' } },
+        { id: String(nextId), position, data: { title: '', text: '', image: '' } },
       ]);
     }
   };
@@ -201,41 +204,14 @@ export default function Editor() {
         </div>
         <div className="w-64 border-l flex flex-col">
           {selected && (
-            <div className="p-2 space-y-2 flex-1 overflow-auto">
-              <textarea
-                className="w-full border p-1"
-                rows={6}
-                value={(selected.data as any).label}
-                onChange={(e) =>
-                  setNodes((nds) =>
-                    nds.map((n) =>
-                      n.id === selected.id
-                        ? { ...n, data: { ...n.data, label: e.target.value } }
-                        : n
-                    )
-                  )
-                }
-              />
-              <ImageUpload
-                nodeId={selected.id}
-                onUrl={(url) =>
-                  setNodes((nds) =>
-                    nds.map((n) =>
-                      n.id === selected.id
-                        ? { ...n, data: { ...n.data, image: url } }
-                        : n
-                    )
-                  )
-                }
-              />
-              {(selected.data as any).image && (
-                <img
-                  src={(selected.data as any).image}
-                  alt=""
-                  className="w-full"
-                />
-              )}
-            </div>
+            <NodeEditor
+              node={selected}
+              nodes={nodes}
+              setNodes={setNodes}
+              edges={edges}
+              setEdges={setEdges}
+              setSelected={setSelected}
+            />
           )}
           <ExportPanel nodes={nodes} edges={edges} />
         </div>

--- a/packages/editor-web/src/ExportPanel.tsx
+++ b/packages/editor-web/src/ExportPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Edge, Node } from 'reactflow';
-import { supabase } from './supabaseClient';
+import { api } from './supabaseClient';
 
 export default function ExportPanel({
   nodes,
@@ -19,6 +19,11 @@ export default function ExportPanel({
         setError(`Missing target for edge ${e.id}`);
         return;
       }
+    }
+    const issues = await api.validate_graph(api.client);
+    if (issues.length > 0) {
+      setError(issues.map((i) => `Node ${i.nodeId}: ${i.message}`).join('\n'));
+      return;
     }
     setError(null);
     const actions: Record<string, { id: string; label: string; target: string }[]> = {};
@@ -49,8 +54,8 @@ export default function ExportPanel({
       type: 'application/json',
     });
     const path = `exports/${story.id}/story.json`;
-    await supabase.storage.from('exports').upload(path, blob, { upsert: true });
-    const { data } = supabase.storage.from('exports').getPublicUrl(path);
+    await api.client.storage.from('exports').upload(path, blob, { upsert: true });
+    const { data } = api.client.storage.from('exports').getPublicUrl(path);
     setLink(data.publicUrl);
   };
 

--- a/packages/editor-web/src/ImageUpload.tsx
+++ b/packages/editor-web/src/ImageUpload.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { supabase } from './supabaseClient';
+import { api } from './supabaseClient';
 
 export default function ImageUpload({
   nodeId,
@@ -14,7 +14,7 @@ export default function ImageUpload({
   const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (file.size > 1024 * 1024) {
+    if (file.size > 20 * 1024 * 1024) {
       setError('File too large');
       return;
     }
@@ -25,7 +25,7 @@ export default function ImageUpload({
     setError(null);
     const path = `${nodeId}/${Date.now()}-${file.name}`;
     setProgress(50);
-    const { error: uploadError } = await supabase.storage
+    const { error: uploadError } = await api.client.storage
       .from('images')
       .upload(path, file, { upsert: true });
     if (uploadError) {
@@ -34,7 +34,7 @@ export default function ImageUpload({
       return;
     }
     setProgress(100);
-    const { data } = supabase.storage.from('images').getPublicUrl(path);
+    const { data } = api.client.storage.from('images').getPublicUrl(path);
     onUrl(data.publicUrl);
   };
 

--- a/packages/editor-web/src/NodeEditor.tsx
+++ b/packages/editor-web/src/NodeEditor.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react';
+import { Node, Edge } from 'reactflow';
+import ImageUpload from './ImageUpload';
+
+interface Props {
+  node: Node;
+  nodes: Node[];
+  setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
+  edges: Edge[];
+  setEdges: React.Dispatch<React.SetStateAction<Edge[]>>;
+  setSelected: React.Dispatch<React.SetStateAction<Node | null>>;
+}
+
+export default function NodeEditor({ node, nodes, setNodes, edges, setEdges, setSelected }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [idInput, setIdInput] = useState(node.id);
+  const outgoing = edges.filter((e) => e.source === node.id);
+
+  useEffect(() => {
+    setIdInput(node.id);
+  }, [node.id]);
+
+  const updateNode = (data: any) =>
+    setNodes((nds) => nds.map((n) => (n.id === node.id ? { ...n, data: { ...n.data, ...data } } : n)));
+
+  const setButtonCount = (count: number) => {
+    const current = outgoing.length;
+    if (count > current) {
+      const newEdges: Edge[] = [];
+      for (let i = current; i < count; i++) {
+        newEdges.push({ id: crypto.randomUUID(), source: node.id, target: node.id, label: '' });
+      }
+      setEdges((eds) => [...eds, ...newEdges]);
+    } else if (count < current) {
+      const remove = outgoing.slice(count).map((e) => e.id);
+      setEdges((eds) => eds.filter((e) => !remove.includes(e.id)));
+    }
+  };
+
+  const updateEdge = (id: string, data: Partial<Edge>) =>
+    setEdges((eds) => eds.map((e) => (e.id === id ? { ...e, ...data } : e)));
+
+  const saveId = () => {
+    const num = parseInt(idInput, 10);
+    if (isNaN(num)) {
+      setError('ID must be a number');
+      return;
+    }
+    if (nodes.some((n) => n.id !== node.id && n.id === String(num))) {
+      setError('ID already exists');
+      return;
+    }
+    setNodes((nds) =>
+      nds.map((n) => (n.id === node.id ? { ...n, id: String(num) } : n))
+    );
+    setEdges((eds) =>
+      eds.map((e) => ({
+        ...e,
+        source: e.source === node.id ? String(num) : e.source,
+        target: e.target === node.id ? String(num) : e.target,
+      }))
+    );
+    setSelected((cur) => (cur && cur.id === node.id ? { ...cur, id: String(num) } : cur));
+    setError(null);
+  };
+
+  useEffect(() => {
+    if (!node.data.title) {
+      setError('Title is required');
+      return;
+    }
+    if (nodes.some((n) => n.id !== node.id && n.id === idInput)) {
+      setError('ID already exists');
+      return;
+    }
+    for (const e of outgoing) {
+      if (!nodes.find((n) => n.id === e.target)) {
+        setError(`Target ${e.target} does not exist`);
+        return;
+      }
+    }
+    setError(null);
+  }, [node, outgoing, nodes, idInput]);
+
+  return (
+    <div className="p-2 space-y-2 flex-1 overflow-auto">
+      <div className="flex items-center space-x-2">
+        <input
+          type="number"
+          className="border p-1 w-20"
+          value={idInput}
+          onChange={(e) => setIdInput(e.target.value)}
+        />
+        <button
+          onClick={saveId}
+          className="px-2 py-1 bg-gray-200 rounded"
+        >
+          Update ID
+        </button>
+      </div>
+      <input
+        className="w-full border p-1"
+        placeholder="Title"
+        value={(node.data as any).title || ''}
+        onChange={(e) => updateNode({ title: e.target.value })}
+      />
+      <textarea
+        className="w-full border p-1"
+        rows={6}
+        placeholder="Description"
+        value={(node.data as any).text || ''}
+        onChange={(e) => updateNode({ text: e.target.value })}
+      />
+      <ImageUpload
+        nodeId={node.id}
+        onUrl={(url) => updateNode({ image: url })}
+      />
+      {(node.data as any).image && <img src={(node.data as any).image} alt="" className="w-full" />}
+      <div>
+        <label className="block text-sm">Buttons</label>
+        <select
+          className="border p-1"
+          value={outgoing.length}
+          onChange={(e) => setButtonCount(parseInt(e.target.value, 10))}
+        >
+          {[1, 2, 3, 4].map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <div className="space-y-2 mt-2">
+          {outgoing.map((e, idx) => (
+            <div key={e.id} className="space-y-1">
+              <input
+                className="w-full border p-1"
+                placeholder={`Label ${idx + 1}`}
+                value={(e.label as string) || ''}
+                onChange={(ev) => updateEdge(e.id, { label: ev.target.value })}
+              />
+              <select
+                className="w-full border p-1"
+                value={e.target}
+                onChange={(ev) => updateEdge(e.id, { target: ev.target.value })}
+              >
+                {nodes.map((n) => (
+                  <option key={n.id} value={n.id}>
+                    {(n.data as any).title || n.id}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+      </div>
+      {error && <div className="text-red-500 text-sm">{error}</div>}
+    </div>
+  );
+}
+

--- a/packages/editor-web/src/supabaseClient.ts
+++ b/packages/editor-web/src/supabaseClient.ts
@@ -1,6 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import * as functions from '@supabase-functions';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const api = {
+  ...functions,
+  client: supabase,
+};

--- a/packages/editor-web/tsconfig.json
+++ b/packages/editor-web/tsconfig.json
@@ -9,7 +9,11 @@
     "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@supabase-functions": ["../../supabase/functions/index.ts"],
+      "@supabase-functions/*": ["../../supabase/functions/*"]
+    }
   },
-  "include": ["src"]
+  "include": ["src", "../../supabase/functions"]
 }

--- a/packages/editor-web/vite.config.ts
+++ b/packages/editor-web/vite.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@supabase-functions': path.resolve(__dirname, '../../supabase/functions'),
+    },
+  },
+  server: {
+    fs: {
+      allow: ['..', '../../supabase/functions'],
+    },
+  },
 });

--- a/packages/mobile-app/tsconfig.json
+++ b/packages/mobile-app/tsconfig.json
@@ -11,5 +11,5 @@
     "types": ["react-native", "expo"],
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "../../supabase/functions"]
 }

--- a/packages/server/__tests__/api.test.ts
+++ b/packages/server/__tests__/api.test.ts
@@ -1,0 +1,18 @@
+import nock from 'nock';
+import { api } from '../index';
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+test('supabase client loads', () => {
+  expect(api.client).toBeDefined();
+});
+
+test('validate_graph RPC call', async () => {
+  nock('http://localhost')
+    .post('/rest/v1/rpc/validate_graph')
+    .reply(200, [{ nodeId: 1, message: 'dup' }]);
+  const res = await api.validate_graph(api.client);
+  expect(res).toEqual([{ nodeId: 1, message: 'dup' }]);
+});

--- a/packages/server/__tests__/crud.test.ts
+++ b/packages/server/__tests__/crud.test.ts
@@ -1,0 +1,41 @@
+import nock from 'nock';
+
+// Set environment before importing api
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+
+import { api } from '../index';
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+test('CRUD operations via supabase client', async () => {
+  const node = { id: 1, story_id: 's', text: 'hi' };
+
+  // insert
+  nock('http://localhost')
+    .post('/rest/v1/nodes')
+    .query({ select: '*' })
+    .reply(201, [node]);
+
+  const insertRes = await api.client.from('nodes').insert(node).select();
+  expect(insertRes.data).toEqual([node]);
+
+  const updated = { ...node, text: 'bye' };
+  nock('http://localhost')
+    .patch('/rest/v1/nodes')
+    .query({ id: 'eq.1', select: '*' })
+    .reply(200, [updated]);
+
+  const updateRes = await api.client.from('nodes').update({ text: 'bye' }).eq('id', 1).select();
+  expect(updateRes.data).toEqual([updated]);
+
+  nock('http://localhost')
+    .delete('/rest/v1/nodes')
+    .query({ id: 'eq.1' })
+    .reply(204);
+
+  const deleteRes = await api.client.from('nodes').delete().eq('id', 1);
+  expect(deleteRes.error).toBeNull();
+});

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -1,0 +1,22 @@
+import { createClient } from '@supabase/supabase-js';
+import * as functions from '../../supabase/functions';
+
+const url = process.env.SUPABASE_URL || 'http://localhost';
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 'public-anon-key';
+
+export const supabase = createClient(url, serviceKey);
+export const api = {
+  ...functions,
+  client: supabase,
+};
+
+// Example usage: fetch all nodes
+async function main() {
+  const { data, error } = await api.client.from('nodes').select('*');
+  if (error) throw error;
+  console.log(data);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "server",
+  "version": "0.0.1",
+  "main": "index.ts",
+  "scripts": {
+    "start": "ts-node index.ts",
+    "test": "jest -c ../../jest.config.cjs"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.50.0"
+  }
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["index.ts", "../../supabase/functions"]
+}

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -6,7 +6,9 @@
     "outDir": "dist",
     "strict": true,
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": []
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^30.0.2
         version: 30.0.2
+      nock:
+        specifier: ^13.4.0
+        version: 13.5.6
       react-test-renderer:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -181,6 +184,12 @@ importers:
       react-native-screens:
         specifier: ^3.25.0
         version: 3.37.0(react-native@0.73.4(@babel/core@7.27.4)(@babel/preset-env@7.27.2(@babel/core@7.27.4))(react@19.1.0))(react@19.1.0)
+
+  packages/server:
+    dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.50.0
+        version: 2.50.0
 
   packages/shared-types:
     dependencies:
@@ -1152,7 +1161,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.17.13':
     resolution: {integrity: sha512-n13yxOmI3I0JidzMdFCH68tYKGDtK4XlDFk1vysZX7AIRKeDVRsSbHhma5jCla2bDt25RKmJBHA9KtzielwzAA==}
@@ -4002,6 +4011,9 @@ packages:
     resolution: {integrity: sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==}
     engines: {node: '>=6.0.0'}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -4458,6 +4470,10 @@ packages:
     resolution: {integrity: sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==}
     engines: {node: '>=12.0.0'}
 
+  nock@13.5.6:
+    resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
+    engines: {node: '>= 10.13'}
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -4796,6 +4812,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  propagate@2.0.1:
+    resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
+    engines: {node: '>= 8'}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -10865,6 +10885,8 @@ snapshots:
       traverse: 0.6.11
       valid-url: 1.0.9
 
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
 
   jsonfile@4.0.0:
@@ -11361,6 +11383,14 @@ snapshots:
 
   nocache@3.0.4: {}
 
+  nock@13.5.6:
+    dependencies:
+      debug: 4.4.1
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   node-abort-controller@3.1.1: {}
 
   node-dir@0.1.17:
@@ -11677,6 +11707,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  propagate@2.0.1: {}
 
   pump@3.0.3:
     dependencies:

--- a/supabase/functions/index.ts
+++ b/supabase/functions/index.ts
@@ -1,0 +1,3 @@
+export * from './upsert_node';
+export * from './validate_graph';
+export * from './search_nodes';

--- a/supabase/functions/search_nodes.ts
+++ b/supabase/functions/search_nodes.ts
@@ -1,0 +1,13 @@
+export interface NodeSearchResult {
+  id: number;
+  title: string;
+}
+
+export const search_nodes = async (
+  supabase: any,
+  query: string
+): Promise<NodeSearchResult[]> => {
+  const { data, error } = await supabase.rpc('search_nodes', { query });
+  if (error) throw error;
+  return data as NodeSearchResult[];
+};

--- a/supabase/functions/upsert_node.ts
+++ b/supabase/functions/upsert_node.ts
@@ -1,0 +1,7 @@
+export const upsert_node = async (supabase: any, payload: any) => {
+  // TODO: implement upsert logic with validation
+  // placeholder returns the inserted or updated node
+  const { data, error } = await supabase.rpc('upsert_node', { payload });
+  if (error) throw error;
+  return data;
+};

--- a/supabase/functions/validate_graph.ts
+++ b/supabase/functions/validate_graph.ts
@@ -1,0 +1,10 @@
+export interface ValidationError {
+  nodeId: number;
+  message: string;
+}
+
+export const validate_graph = async (supabase: any): Promise<ValidationError[]> => {
+  const { data, error } = await supabase.rpc('validate_graph');
+  if (error) throw error;
+  return data as ValidationError[];
+};


### PR DESCRIPTION
## Summary
- add NodeEditor component with title, description, image upload and button controls
- store numeric node IDs and create nodes sequentially
- update editor to use the new NodeEditor panel
- allow editing node numeric ID, validate uniqueness and update connected edges
- prevent oversize uploads and detect orphans via validate_graph RPC

## Testing
- `pnpm -r run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685bac265a3c832991a412e9269b0d7d