### PR TITLE
Implement spec phase 3 editor features

### DIFF
--- a/packages/editor-web/src/StoryNode.tsx
+++ b/packages/editor-web/src/StoryNode.tsx
@@ -1,0 +1,20 @@
+import { NodeProps, Handle, Position } from 'reactflow';
+
+export default function StoryNode({ id, data }: NodeProps) {
+  const { title, image } = data as any;
+  return (
+    <div className="bg-white rounded border text-xs w-32">
+      {image && (
+        <div
+          className="h-16 bg-cover bg-center rounded-t"
+          style={{ backgroundImage: `url(${image})` }}
+        />
+      )}
+      <div className="p-1 text-center font-medium">
+        {id} &middot; {title || '(untitled)'}
+      </div>
+      <Handle type="source" position={Position.Right} />
+      <Handle type="target" position={Position.Left} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add custom `StoryNode` renderer with ID and image
- polish editor: highlight orphan nodes and dangling edges
- implement keyboard shortcuts (cmd/ctrl+S, cmd/ctrl+F, undo/redo)
- maintain limited history for undo/redo

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685e85fd5fc4832981332af2bfc4a0f7