### PR TITLE
Provision Supabase in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - run: pnpm --filter shared-types build
       - run: pnpm --filter editor-web build
       - run: pnpm --filter mobile-app build
+      - name: Install Supabase CLI
+        run: npm install -g supabase@latest
+      - name: Provision Supabase
+        run: ./supabase/provision.sh
+        env:
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
       - name: Set up Expo
         uses: expo/expo-github-action@v8
         with:


### PR DESCRIPTION
## Summary
- install Supabase CLI and run provisioning script during CI
- use the SUPABASE_PROJECT_ID secret

## Testing
- `pnpm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eb60bf0b883299cf049820ce0aff9