### PR TITLE
Handle Supabase load errors in editor

### DIFF
--- a/packages/editor-web/src/Editor.tsx
+++ b/packages/editor-web/src/Editor.tsx
@@ -27,6 +27,7 @@ export default function Editor() {
   const [history, setHistory] = useState<{ nodes: Node[]; edges: Edge[] }[]>([]);
   const [future, setFuture] = useState<{ nodes: Node[]; edges: Edge[] }[]>([]);
   const [selected, setSelected] = useState<Node | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const reactFlow = useReactFlow();
   const nodeTypes: NodeTypes = { story: StoryNode };
 
@@ -35,9 +36,14 @@ export default function Editor() {
   }, []);
 
   const load = async () => {
-    const { data: nodeData } = await api.client
+    setError(null);
+    const { data: nodeData, error: nodeError } = await api.client
       .from('nodes')
       .select('id, title, text, image_url');
+    if (nodeError) {
+      console.error(nodeError);
+      setError(nodeError.message);
+    }
     if (nodeData) {
       const loadedNodes: Node[] = nodeData.map((n: any, idx: number) => ({
         id: String(n.id),
@@ -48,9 +54,13 @@ export default function Editor() {
       setNodes(loadedNodes);
     }
 
-    const { data: actionData } = await api.client
+    const { data: actionData, error: actionError } = await api.client
       .from('actions')
       .select('id, node_id, target_id, label');
+    if (actionError) {
+      console.error(actionError);
+      setError(actionError.message);
+    }
     if (actionData) {
       const loadedEdges: Edge[] = actionData.map((a: any) => ({
         id: a.id,
@@ -241,7 +251,7 @@ export default function Editor() {
 
   return (
       <div className="h-screen flex">
-        <Sidebar />
+        <Sidebar error={error} />
         <div className="flex-1" onDrop={onDrop} onDragOver={onDragOver}>
           <div className="p-2 space-x-2">
             <button onClick={addNode} className="bg-blue-500 text-white px-2 py-1 rounded">Add Node</button>

--- a/packages/editor-web/src/Sidebar.tsx
+++ b/packages/editor-web/src/Sidebar.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
-export default function Sidebar() {
+export default function Sidebar({ error }: { error: string | null }) {
   const onDragStart = (event: React.DragEvent<HTMLDivElement>, nodeType: string) => {
     event.dataTransfer.setData('application/reactflow', nodeType);
     event.dataTransfer.effectAllowed = 'move';
   };
 
   return (
-    <aside className="w-40 p-2 border-r">
+    <aside className="w-40 p-2 border-r space-y-2">
+      {error && (
+        <div className="bg-red-100 text-red-700 p-2 rounded text-sm">{error}</div>
+      )}
       <div
         className="p-2 bg-gray-200 rounded cursor-grab"
         onDragStart={(event) => onDragStart(event, 'default')}


### PR DESCRIPTION
## Summary
- capture errors when fetching nodes and actions
- store error message in state and pass it to `Sidebar`
- display alert in the sidebar for backend errors

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec46870d08329b64973a028e82371