### PR TITLE
Remove parseInt calls

### DIFF
--- a/packages/editor-web/src/Editor.tsx
+++ b/packages/editor-web/src/Editor.tsx
@@ -114,7 +114,7 @@ export default function Editor() {
   const addNode = () => {
     setHistory((h) => [...h.slice(-9), { nodes, edges }]);
     const nextId =
-      nodes.reduce((max, n) => Math.max(max, parseInt(n.id, 10)), 0) + 1;
+      nodes.reduce((max, n) => Math.max(max, Number(n.id)), 0) + 1;
     setNodes((nds) => [
       ...nds,
       {
@@ -137,7 +137,7 @@ export default function Editor() {
     if (type) {
       const position = reactFlow.project({ x: event.clientX, y: event.clientY });
       const nextId =
-        nodes.reduce((max, n) => Math.max(max, parseInt(n.id, 10)), 0) + 1;
+        nodes.reduce((max, n) => Math.max(max, Number(n.id)), 0) + 1;
       setNodes((nds) => [
         ...nds,
         {

--- a/packages/editor-web/src/NodeEditor.tsx
+++ b/packages/editor-web/src/NodeEditor.tsx
@@ -122,7 +122,7 @@ export default function NodeEditor({ node, nodes, setNodes, edges, setEdges, set
         <select
           className="border p-1"
           value={outgoing.length}
-          onChange={(e) => setButtonCount(parseInt(e.target.value, 10))}
+          onChange={(e) => setButtonCount(Number(e.target.value))}
         >
           {[1, 2, 3, 4].map((c) => (
             <option key={c} value={c}>


### PR DESCRIPTION
## Summary
- remove redundant `parseInt` usage when calculating new node IDs
- remove `parseInt` when updating button count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fea40bb608329a64d378b589f67de