### PR TITLE
Use UUID for node IDs

### DIFF
--- a/packages/editor-web/src/Editor.tsx
+++ b/packages/editor-web/src/Editor.tsx
@@ -78,7 +78,7 @@ export default function Editor() {
         .from('nodes')
         .upsert(
           nodes.map((n) => ({
-            id: parseInt(n.id, 10),
+            id: n.id,
             title: (n.data as any).title,
             text: (n.data as any).text,
             image_url: (n.data as any).image ?? null,
@@ -113,12 +113,11 @@ export default function Editor() {
 
   const addNode = () => {
     setHistory((h) => [...h.slice(-9), { nodes, edges }]);
-    const nextId =
-      nodes.reduce((max, n) => Math.max(max, Number(n.id)), 0) + 1;
+    const newId = crypto.randomUUID();
     setNodes((nds) => [
       ...nds,
       {
-        id: String(nextId),
+        id: newId,
         type: 'story',
         position: { x: 0, y: nds.length * 80 },
         data: { title: '', text: '', image: '' },
@@ -136,12 +135,11 @@ export default function Editor() {
     const type = event.dataTransfer.getData('application/reactflow');
     if (type) {
       const position = reactFlow.project({ x: event.clientX, y: event.clientY });
-      const nextId =
-        nodes.reduce((max, n) => Math.max(max, Number(n.id)), 0) + 1;
+      const newId = crypto.randomUUID();
       setNodes((nds) => [
         ...nds,
         {
-          id: String(nextId),
+          id: newId,
           type: 'story',
           position,
           data: { title: '', text: '', image: '' },


### PR DESCRIPTION
## Summary
- remove numeric parsing when saving nodes
- generate new node IDs using `crypto.randomUUID`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6863e739bb3c8329b3d875f0c7bb9018