### PR TITLE
Fix Supabase ID types

### DIFF
--- a/packages/editor-web/src/Editor.tsx
+++ b/packages/editor-web/src/Editor.tsx
@@ -73,8 +73,8 @@ export default function Editor() {
   };
 
   const save = useCallback(
-    (nodes: Node[], edges: Edge[]) => {
-      api.client
+    async (nodes: Node[], edges: Edge[]) => {
+      await api.client
         .from('nodes')
         .upsert(
           nodes.map((n) => ({
@@ -85,7 +85,7 @@ export default function Editor() {
           }))
         );
 
-      api.client
+      await api.client
         .from('actions')
         .upsert(
           edges.map((e) => ({
@@ -96,7 +96,7 @@ export default function Editor() {
           }))
         );
 
-      api.client.from('revisions').insert({
+      await api.client.from('revisions').insert({
         id: crypto.randomUUID(),
         story_id: 'demo-story',
         data: { nodes, edges },

--- a/packages/server/__tests__/api.test.ts
+++ b/packages/server/__tests__/api.test.ts
@@ -12,7 +12,7 @@ test('supabase client loads', () => {
 test('validate_graph RPC call', async () => {
   nock('http://localhost')
     .post('/rest/v1/rpc/validate_graph')
-    .reply(200, [{ nodeId: 1, message: 'dup' }]);
+    .reply(200, [{ nodeId: '1', message: 'dup' }]);
   const res = await api.validate_graph(api.client);
-  expect(res).toEqual([{ nodeId: 1, message: 'dup' }]);
+  expect(res).toEqual([{ nodeId: '1', message: 'dup' }]);
 });

--- a/packages/server/__tests__/crud.test.ts
+++ b/packages/server/__tests__/crud.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 });
 
 test('CRUD operations via supabase client', async () => {
-  const node = { id: 1, story_id: 's', text: 'hi' };
+  const node = { id: '1', story_id: 's', text: 'hi' };
 
   // insert
   nock('http://localhost')
@@ -28,7 +28,7 @@ test('CRUD operations via supabase client', async () => {
     .query({ id: 'eq.1', select: '*' })
     .reply(200, [updated]);
 
-  const updateRes = await api.client.from('nodes').update({ text: 'bye' }).eq('id', 1).select();
+  const updateRes = await api.client.from('nodes').update({ text: 'bye' }).eq('id', '1').select();
   expect(updateRes.data).toEqual([updated]);
 
   nock('http://localhost')
@@ -36,6 +36,6 @@ test('CRUD operations via supabase client', async () => {
     .query({ id: 'eq.1' })
     .reply(204);
 
-  const deleteRes = await api.client.from('nodes').delete().eq('id', 1);
+  const deleteRes = await api.client.from('nodes').delete().eq('id', '1');
   expect(deleteRes.error).toBeNull();
 });

--- a/supabase/functions/search_nodes.ts
+++ b/supabase/functions/search_nodes.ts
@@ -1,5 +1,5 @@
 export interface NodeSearchResult {
-  id: number;
+  id: string;
   title: string;
 }
 

--- a/supabase/functions/upsert_node.ts
+++ b/supabase/functions/upsert_node.ts
@@ -3,11 +3,11 @@ import { z } from 'zod';
 const Action = z.object({
   id: z.string().optional(),
   label: z.string(),
-  target_id: z.number(),
+  target_id: z.string(),
 });
 
 const Node = z.object({
-  id: z.number(),
+  id: z.string(),
   title: z.string(),
   text: z.string(),
   image_url: z.string().nullable().optional(),

--- a/supabase/functions/validate_graph.ts
+++ b/supabase/functions/validate_graph.ts
@@ -1,5 +1,5 @@
 export interface ValidationError {
-  nodeId: number;
+  nodeId: string;
   message: string;
 }
 


### PR DESCRIPTION
## Summary
- update Supabase wrapper types to use string UUIDs
- wait for RPC calls when saving from the editor
- update API tests for new string IDs

## Testing
- `pnpm -r test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e69b05c08329ba2ce7bae2ad1d21