### PR TITLE
Add generateId utility for UUIDs

### DIFF
--- a/packages/editor-web/src/Editor.tsx
+++ b/packages/editor-web/src/Editor.tsx
@@ -20,6 +20,7 @@ import Sidebar from './Sidebar';
 import ExportPanel from './ExportPanel';
 import NodeEditor from './NodeEditor';
 import StoryNode from './StoryNode';
+import { generateId } from './id';
 
 export default function Editor() {
   const [nodes, setNodes, onNodesChange] = useNodesState([] as Node[]);
@@ -97,7 +98,7 @@ export default function Editor() {
         );
 
       await api.client.from('revisions').insert({
-        id: crypto.randomUUID(),
+        id: generateId(),
         story_id: 'demo-story',
         data: { nodes, edges },
       });
@@ -113,7 +114,7 @@ export default function Editor() {
 
   const addNode = () => {
     setHistory((h) => [...h.slice(-9), { nodes, edges }]);
-    const newId = crypto.randomUUID();
+    const newId = generateId();
     setNodes((nds) => [
       ...nds,
       {
@@ -135,7 +136,7 @@ export default function Editor() {
     const type = event.dataTransfer.getData('application/reactflow');
     if (type) {
       const position = reactFlow.project({ x: event.clientX, y: event.clientY });
-      const newId = crypto.randomUUID();
+      const newId = generateId();
       setNodes((nds) => [
         ...nds,
         {

--- a/packages/editor-web/src/NodeEditor.tsx
+++ b/packages/editor-web/src/NodeEditor.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { Node, Edge } from 'reactflow';
 import ImageUpload from './ImageUpload';
 import { formatId } from './utils';
+import { generateId } from './id';
 
 interface Props {
   node: Node;
@@ -29,7 +30,7 @@ export default function NodeEditor({ node, nodes, setNodes, edges, setEdges, set
     if (count > current) {
       const newEdges: Edge[] = [];
       for (let i = current; i < count; i++) {
-        newEdges.push({ id: crypto.randomUUID(), source: node.id, target: node.id, label: '' });
+        newEdges.push({ id: generateId(), source: node.id, target: node.id, label: '' });
       }
       setEdges((eds) => [...eds, ...newEdges]);
     } else if (count < current) {

--- a/packages/editor-web/src/id.ts
+++ b/packages/editor-web/src/id.ts
@@ -1,0 +1,35 @@
+export function generateId(): string {
+  // Prefer native crypto.randomUUID if available
+  if (typeof crypto !== 'undefined') {
+    if (typeof (crypto as any).randomUUID === 'function') {
+      return (crypto as any).randomUUID();
+    }
+    if (typeof crypto.getRandomValues === 'function') {
+      const bytes = new Uint8Array(16);
+      crypto.getRandomValues(bytes);
+      // Per RFC4122 version 4
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      return (
+        hex.slice(0, 8) +
+        '-' +
+        hex.slice(8, 12) +
+        '-' +
+        hex.slice(12, 16) +
+        '-' +
+        hex.slice(16, 20) +
+        '-' +
+        hex.slice(20)
+      );
+    }
+  }
+  // Fallback using Math.random
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
## Summary
- create `generateId` helper with fallback implementations
- replace direct `crypto.randomUUID()` uses in editor

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6863f972159c8329acc2d3dedbb07180