### PR TITLE
Fix export text property

### DIFF
--- a/packages/editor-web/__tests__/export-panel.test.tsx
+++ b/packages/editor-web/__tests__/export-panel.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import ExportPanel from '../src/ExportPanel';
+import { Node, Edge } from 'reactflow';
+jest.mock('../src/supabaseClient');
+const { uploadMock, fromMock, getPublicUrlMock } = jest.requireMock('../src/supabaseClient');
+
+describe('ExportPanel', () => {
+  let OriginalBlob: typeof Blob;
+  let captured: any[] = [];
+  beforeEach(() => {
+    uploadMock.mockReset();
+    fromMock.mockReturnValue({ upload: uploadMock, getPublicUrl: getPublicUrlMock });
+    OriginalBlob = global.Blob;
+    global.Blob = class extends OriginalBlob {
+      constructor(parts: any[], options?: any) {
+        super(parts, options);
+        captured = parts;
+      }
+    } as unknown as typeof Blob;
+  });
+  afterEach(() => {
+    global.Blob = OriginalBlob;
+  });
+
+  it('exports node text', async () => {
+    const nodes: Node[] = [
+      { id: '1', position: { x: 0, y: 0 }, data: { text: 'hello' } } as any,
+    ];
+    const edges: Edge[] = [];
+    const { getByText } = render(<ExportPanel nodes={nodes} edges={edges} />);
+
+    fireEvent.click(getByText('Export Story'));
+
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
+    const json = JSON.parse(captured[0]);
+    expect(json.nodes[0].text).toBe('hello');
+  });
+});

--- a/packages/editor-web/src/ExportPanel.tsx
+++ b/packages/editor-web/src/ExportPanel.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState } from 'react';
 import { Edge, Node } from 'reactflow';
 import { api } from './supabaseClient';
@@ -22,7 +23,7 @@ export default function ExportPanel({
     }
     const issues = await api.validate_graph(api.client);
     if (issues.length > 0) {
-      setError(issues.map((i) => `Node ${i.nodeId}: ${i.message}`).join('\n'));
+      setError(issues.map((i: any) => `Node ${i.nodeId}: ${i.message}`).join('\n'));
       return;
     }
     setError(null);
@@ -39,7 +40,7 @@ export default function ExportPanel({
       id: 'demo-story',
       nodes: nodes.map((n) => ({
         id: n.id,
-        text: (n.data as any).label,
+        text: (n.data as any).text,
         image: (n.data as any).image ?? '',
         actions: actions[n.id] ?? [],
       })),

--- a/packages/editor-web/src/__mocks__/supabaseClient.ts
+++ b/packages/editor-web/src/__mocks__/supabaseClient.ts
@@ -1,0 +1,9 @@
+export const uploadMock = jest.fn();
+export const getPublicUrlMock = jest.fn(() => ({ data: { publicUrl: 'http://url' } }));
+export const fromMock = jest.fn(() => ({ upload: uploadMock, getPublicUrl: getPublicUrlMock }));
+export const api = {
+  validate_graph: jest.fn().mockResolvedValue([]),
+  client: {
+    storage: { from: fromMock },
+  },
+};


### PR DESCRIPTION
## Summary
- export node `text` in ExportPanel
- add unit test for ExportPanel export
- add manual mock for supabase client used in tests

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6863fbc79b0083299063e55687b67054